### PR TITLE
FIX: Extend UserFormsRequiredFields

### DIFF
--- a/src/Extension/UserFormValidatorExtension.php
+++ b/src/Extension/UserFormValidatorExtension.php
@@ -2,10 +2,10 @@
 
 namespace Sunnysideup\UserformsBlockSpamWithKeywords\Extension;
 
-use SilverStripe\UserForms\Extension\UserFormValidator;
+use SilverStripe\UserForms\Form\UserFormsRequiredFields;
 use Sunnysideup\UserformsBlockSpamWithKeywords\Model\SpamTextToBlock;
 
-class UserFormValidatorExtension extends UserFormValidator
+class UserFormValidatorExtension extends UserFormsRequiredFields
 {
     public function php($data)
     {


### PR DESCRIPTION
UserFormValidatorExtension replaces the UserFormsRequiredFields class in the config, but it extends a different RequiredFields child - UserFormValidator.

UserFormsRequiredFields is the class that supports conditionally required fields. By injecting a different class over it, conditionally required fields break on user forms.

This changes the extension to extend UserFormsRequiredFields instead, which fixes conditionally required fields.